### PR TITLE
Read and review published issue

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -147,6 +147,7 @@ document.addEventListener('DOMContentLoaded', function () {
     function clearAnalysisResult() {
         const resultDiv = document.getElementById('analysisResult');
         resultDiv.innerHTML = '';
+        currentAnalysisData = null;
     }
 
     function displayAnalysisResult(analysisData) {


### PR DESCRIPTION
When a new analysis is initiated, the clearAnalysisResult() function was only clearing the DOM elements but not the currentAnalysisData global variable. This caused old session data to persist in memory and display when users toggled views, making it appear as if the app was "keeps fetching the previous session without retrieving it back".

Now currentAnalysisData is properly reset to null when clearing analysis results, ensuring fresh data is displayed for each new analysis session.

Fixes #1: previous session details